### PR TITLE
Fix the reference mistake

### DIFF
--- a/koa/tutorial/models/tutorialTree.js
+++ b/koa/tutorial/models/tutorialTree.js
@@ -110,7 +110,8 @@ module.exports = class TutorialTree {
     // console.log("DESTROY", slug);
 
     if (entry.children) {
-      for (let childSlug of entry.children) {
+      // Working with an items list reference. Items keys should be detached
+      for (let childSlug of [...entry.children]) {
         this.destroyTree(childSlug);
       }
     }


### PR DESCRIPTION
Ok. There is what I found.

I ran the server and edited a folder entry (any index.md may be there). I catch the issue

```
21:58:55.787Z ERROR importWatch: Already exists an entry with slug:coding-style
    Error: Already exists an entry with slug:coding-style
        at TutorialTree.add (/user/javascript-tutorial_server/modules/engine/koa/tutorial/models/tutorialTree.js:135:13)
        at TutorialImporter.syncArticle (/user/javascript-tutorial_server/modules/engine/koa/tutorial/lib/tutorialImporter.js:227:15)
        at processTicksAndRejections (internal/process/task_queues.js:89:5)
        at async TutorialImporter.syncFolder (/user/javascript-tutorial_server/modules/engine/koa/tutorial/lib/tutorialImporter.js:150:9)
        at async TutorialImporter.sync (/user/javascript-tutorial_server/modules/engine/koa/tutorial/lib/tutorialImporter.js:86:5)
```
As I can see this is due to the fact that not all children are removed as needed. They are deleted through one. Because in the for loop we use a dynamic reference to the array that changes within itself.