### PR TITLE
Add CodeFund to sidebar

### DIFF
--- a/sidebar/templates/sidebar.pug
+++ b/sidebar/templates/sidebar.pug
@@ -21,3 +21,7 @@ if share
 if githubLink
   +e.section
     +e('a').link(href=githubLink rel="nofollow")= t('site.edit_on_github')
+
++e.section
+  #codefund
+  script(src="https://codefund.io/properties/339/funder.js" async="async")

--- a/sidebar/templates/sidebar.styl
+++ b/sidebar/templates/sidebar.styl
@@ -1,4 +1,7 @@
 .sidebar
+  #codefund
+    padding-top 20px
+
   width sidebar_width - 1
   background #F5F2F0
   border-right 1px solid #d5d2d0


### PR DESCRIPTION
This pull request adds ethical CodeFund ads to the sidebar section.

Note that the template and theme used for the ad can be changed by editing your property settings at https://codefund.io/

<img width="682" alt="Hello, world! 2019-07-23 10-13-58" src="https://user-images.githubusercontent.com/32920/61728862-3ffd1a00-ad33-11e9-916e-e3382ca70457.png">
