### PR TITLE
fix(domtree): text nodes should render space

### DIFF
--- a/koa/tutorial/client/assets/all-lang/libs/domtree.js
+++ b/koa/tutorial/client/assets/all-lang/libs/domtree.js
@@ -13,7 +13,7 @@ function drawHtmlTree(json, nodeTarget, w, h) {
 
   var i = 0,
     barHeight = 30,
-    barWidth = 250,
+    barWidth = 350,
     barMargin = 2.5,
     barRadius = 4,
     duration = 400,
@@ -74,6 +74,11 @@ function drawHtmlTree(json, nodeTarget, w, h) {
         if (d.content) {
           if (/^\s*$/.test(d.content)) {
             text += " " + d.content.replace(/\n/g, "↵").replace(/ /g, '␣');
+          } else if(/\s*.+\s*/.test(d.content)) {
+            let [_, h, content, t] = d.content.match(/(\s*)(.+)(\s*)/)
+            h = h.replace(/\n/g, "↵").replace(/ /g, '␣');
+            t = t.replace(/\n/g, "↵").replace(/ /g, '␣');
+            text += " " + h + content + t
           } else {
             text += " " + d.content;
           }


### PR DESCRIPTION
According to https://github.com/javascript-tutorial/en.javascript.info/pull/2293#issuecomment-733519822, though content is correct, the blank "␣" and "\n" didn't be painted correctly. This PR tries to fix the issue.

The result is as follows:

![image](https://user-images.githubusercontent.com/47357585/136065108-d3235f75-f8b0-416d-99b2-12322c2bd62b.png)

Related: javascript-tutorial/zh.javascript.info#829 and javascript-tutorial/en.javascript.info#2294.