### PR TITLE
Fix incorrect argument passing due to dependency API change

### DIFF
--- a/markit/loadImgSizeAsync.js
+++ b/markit/loadImgSizeAsync.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 assert(typeof IS_CLIENT === 'undefined');
 
 const { promisify } = require('util');
-const imageSize = promisify(require('image-size'));
+const imageSize = promisify(require('image-size').imageSize);
 
 const path = require('path');
 const tokenUtils = require('./utils/token');


### PR DESCRIPTION
This fixes the following error when running the server and solves https://github.com/javascript-tutorial/server/issues/108
```
node:internal/errors:540
      throw error;
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function. Received an instance of Object
    at promisify (node:internal/util:423:3)
    at Object.<anonymous> (/home/stanley/repos/javascript.info/js/server/modules/engine/markit/loadImgSizeAsync.js:8:19)
    at Module._compile (node:internal/modules/cjs/loader:1554:14)
    at Object..js (node:internal/modules/cjs/loader:1706:10)
    at Module.load (node:internal/modules/cjs/loader:1289:32)
    at Function._load (node:internal/modules/cjs/loader:1108:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:220:24)
    at Module.require (node:internal/modules/cjs/loader:1311:12)
    at require (node:internal/modules/helpers:136:16) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

Alternatively, consider:
```
const { promisify } = require('util');
const imgSizeModule = require('image-size');
const imageSizeFn = imgSizeModule.default || imgSizeModule;
const imageSize = promisify(imageSizeFn);
```